### PR TITLE
added default table styling

### DIFF
--- a/src/sass/partials/_article.scss
+++ b/src/sass/partials/_article.scss
@@ -165,6 +165,29 @@ article {
         letter-spacing: 3px;
     }
 
+    table {
+        @include fluid-type(300, 1535, 16, 18, px);
+        margin: 0.5em 0;
+        border-collapse: collapse;
+        tr {
+            background-color: #464866;
+            color: #FFF;
+            th{
+                background-color: #25274d;
+                font-weight: bold;
+                text-align: center;
+                padding: 15px;
+            }
+            td {
+                text-align: left;
+                padding: 15px;
+            }
+        }
+        tr:nth-of-type(2n) {
+            background-color: #54567a;
+        }
+    }
+
     p {
         // font-size: 18px;
         @include fluid-type(300, 1535, 16, 18, px);


### PR DESCRIPTION
This should add default table styling. It is based on the hope website's schedule table thing (https://ieee.berkeley.edu/hope/), so this page don't need to use the id="timeline" class thing anymore. Sorry this took so long, I learned a lot of CSS and Sass. Let me know if anything needs tweaking.